### PR TITLE
remove redundant code and unused imports

### DIFF
--- a/src/components/ToolBar/DataMenu/ExportNetworkToImage/SvgExportForm.tsx
+++ b/src/components/ToolBar/DataMenu/ExportNetworkToImage/SvgExportForm.tsx
@@ -3,7 +3,6 @@ import {
   Button,
   FormControlLabel,
   Checkbox,
-  TextField,
   DialogActions,
   Typography,
 } from '@mui/material'
@@ -12,7 +11,6 @@ import { ReactElement, useState } from 'react'
 import { saveAs } from 'file-saver'
 import { ExportImageFormatProps } from './ExportNetworkToImageMenuItem'
 import { useRendererFunctionStore } from '../../../../store/RendererFunctionStore'
-import { IdType } from '../../../../models/IdType'
 import { useUiStateStore } from '../../../../store/UiStateStore'
 import { useWorkspaceStore } from '../../../../store/WorkspaceStore'
 
@@ -20,21 +18,25 @@ export const SvgExportForm = (props: ExportImageFormatProps): ReactElement => {
   const [loading, setLoading] = useState(false)
   const [fullBg, setFullBg] = useState(true)
 
-  const activeNetworkId: IdType = useUiStateStore(
-    (state) => state.ui.activeNetworkView,
-  )
-  const currentNetworkId: IdType = useWorkspaceStore(
+  const activeNetworkId = useUiStateStore((state) => state.ui.activeNetworkView)
+  const currentNetworkId = useWorkspaceStore(
     (state) => state.workspace.currentNetworkId,
   )
 
-  const targetNetworkId: IdType =
-    activeNetworkId === undefined || activeNetworkId === ''
-      ? currentNetworkId
-      : activeNetworkId
+  const targetNetworkId = activeNetworkId || currentNetworkId
 
   const svgFunction = useRendererFunctionStore((state) =>
     state.getFunction('cyjs', 'exportSvg', targetNetworkId),
   )
+
+  const handleExport = async () => {
+    setLoading(true)
+    const result = await svgFunction?.(fullBg)
+    const blob = new Blob([result], { type: 'image/svg+xml' })
+    saveAs(blob, `${props.fileName}.svg`)
+    setLoading(false)
+    props.handleClose()
+  }
 
   return (
     <Box
@@ -63,17 +65,7 @@ export const SvgExportForm = (props: ExportImageFormatProps): ReactElement => {
         <Button color="error" onClick={props.handleClose}>
           Cancel
         </Button>
-        <Button
-          disabled={loading}
-          onClick={async () => {
-            setLoading(true)
-            const result = await svgFunction?.(fullBg)
-            const blob = new Blob([result], { type: 'image/svg+xml' })
-            saveAs(blob, `${props.fileName}.svg`)
-            setLoading(false)
-            props.handleClose()
-          }}
-        >
+        <Button disabled={loading} onClick={handleExport}>
           Confirm
         </Button>
       </DialogActions>

--- a/src/components/ToolBar/DataMenu/RemoveNetworkMenuItem.tsx
+++ b/src/components/ToolBar/DataMenu/RemoveNetworkMenuItem.tsx
@@ -1,12 +1,11 @@
 import { MenuItem } from '@mui/material'
-import { ReactElement, useEffect, useState } from 'react'
+import { ReactElement, useState } from 'react'
 import { useWorkspaceStore } from '../../../store/WorkspaceStore'
 import { BaseMenuProps } from '../BaseMenuProps'
 import { ConfirmationDialog } from '../../Util/ConfirmationDialog'
 
 export const RemoveNetworkMenuItem = (props: BaseMenuProps): ReactElement => {
   const [open, setOpen] = useState<boolean>(false)
-
   const deleteCurrentNetwork = useWorkspaceStore(
     (state) => state.deleteCurrentNetwork,
   )


### PR DESCRIPTION
The Issue Addressed: 
The issue highlighted redundancies and inefficiencies in the SvgExportForm component, such as unused imports, overly verbose state handling, and convoluted logic for calculating targetNetworkId.

How I Maintained It:
1. Removed Unused Code: Eliminated imports like useEffect and TextField, which were no longer necessary.
2. Function Extraction: Isolated the export logic into a handleExport function to ensure better readability and maintain separation of concerns.
3. Simplified Logic: Refined the targetNetworkId calculation by reducing conditional checks, making the logic more concise and efficient.

The Strategy I Used:
Reductive Maintenance: Focused on simplifying the codebase by removing unnecessary elements and streamlining existing functionality. Emphasized clarity and efficiency while minimizing complexity.

Impact of Changes
Enhanced Readability: The codebase is now cleaner and easier to understand.
Improved Maintainability: Reduced complexity ensures easier debugging and future updates.
Cleaner Code: Adhering to reductive maintenance principles ensures a more concise and efficient implementation.
